### PR TITLE
Multi-threading audio

### DIFF
--- a/threading
+++ b/threading
@@ -1,0 +1,82 @@
+import HRIR
+import ITD
+import soundfile as sf
+import numpy
+import pyaudio
+from Queue import *
+from multiprocessing.pool import threading
+
+audio_lock = threading.Lock()
+
+
+def new_audio(elevation, curr_azimuth):
+    sound_wave, sample_rate = sf.read('white-noise.wav')
+    zero_padding = [0] * int(sample_rate * 0.2)
+    left_hrir = HRIR.HRIR_LEFT_HASH[elevation][curr_azimuth]
+    right_hrir = HRIR.HRIR_RIGHT_HASH[elevation][curr_azimuth]
+    delay = ITD.ITD[elevation][curr_azimuth]
+    zeros_delay = [0] * abs(int(delay))
+    if curr_azimuth > 0:
+        left_audio = numpy.append(zeros_delay, left_hrir)
+        right_audio = numpy.append(right_hrir, zeros_delay)
+    # sound is coming from the left side
+    elif curr_azimuth < 0:
+        left_audio = numpy.append(left_hrir, zeros_delay)
+        right_audio = numpy.append(zeros_delay, right_hrir)
+    left_convolution = numpy.convolve(left_audio, sound_wave, 'full')
+    right_convolution = numpy.convolve(right_audio, sound_wave, 'full')
+    LEFT_SOUND = numpy.append(left_convolution, zero_padding)
+    RIGHT_SOUND = numpy.append(right_convolution, zero_padding)
+    sound_to_play = numpy.array([LEFT_SOUND, RIGHT_SOUND])
+    max_left = max(sound_to_play[0])
+    max_right = max(sound_to_play[1])
+    maximum = max_left if max_left > max_right else max_right
+    sound_to_play = sound_to_play / float(maximum)
+    sound_to_play = numpy.transpose(sound_to_play)
+    sound_to_play = sound_to_play.astype('float32')
+    return sound_to_play
+
+
+ELEVATION = "Elevation 0"
+
+# the rate at which we are reading an audio file
+CHUNK = 1024
+BUFFER = []
+
+# instantiate PyAudio
+p = pyaudio.PyAudio()
+
+# open stream - rate = bit rate or chunk 8192 increase the buffer size 8192
+stream = p.open(format=pyaudio.paFloat32, channels=2, rate=44100, output=True)
+
+
+def render_real_time(data):
+    with audio_lock:
+        data = data.astype(numpy.float32).tostring()
+        stream.write(data, exception_on_underflow=False)
+
+
+def threader():
+    while True:
+        azimuth = queue.get()
+        sound = new_audio(ELEVATION, azimuth)
+        render_real_time(sound)
+        queue.task_done()
+
+
+# queue to store tasks
+queue = Queue()
+AZIMUTHS = [-80, 80]
+list(map(queue.put, AZIMUTHS))
+
+# creates two threads
+for thread in range(2):
+    t = threading.Thread(target=threader)
+    t.daemon = True
+    t.start()
+
+queue.join()
+stream.stop_stream()
+stream.close()
+p.terminate()
+


### PR DESCRIPTION
Future Task: Interupt the first audio anytime so that a new audio can play
Problem: azimuth 80 plays first, then -80 plays even though the order I inserted them was -80 then 80. 
Is there a noticeable gap in the audio between the two azimuths?